### PR TITLE
Add board view with task duration metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# teste
+# Authentication Flow Demo
+
+Este projeto fornece um exemplo simples de tela de login e um quadro de tarefas semelhante ao Trello.
+
+Abra `index.html` em seu navegador para acessar a tela de login. No link da parte inferior é possível acessar `board.html`, onde você pode arrastar tarefas entre colunas e adicionar novas tarefas preenchendo título e datas.

--- a/board.html
+++ b/board.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Quadro de Tarefas</title>
+<style>
+  body {font-family: Arial, sans-serif; margin: 20px; background: #f6f6f6;}
+  h1 {text-align: center; color: #6a0dad;}
+  .board {display: flex; justify-content: space-between; gap: 20px;}
+  .column {background: #fff; border-radius: 4px; flex: 1; padding: 10px; box-shadow: 0 0 5px rgba(0,0,0,0.1);}
+  .column h2 {text-align: center; color: #6a0dad;}
+  .task {border: 1px solid #ddd; border-radius: 4px; padding: 8px; margin-bottom: 10px; background: #fafafa;}
+  .metrics {font-size: 0.85em; color: #555; margin-top: 4px;}
+</style>
+</head>
+<body>
+<h1>MVP de Gerenciamento de Tarefas</h1>
+<div class="board">
+  <div class="column">
+    <h2>A Fazer</h2>
+    <div class="task" data-start="2024-06-01T09:00" data-end="2024-06-01T11:00">
+      <strong>Configurar login</strong>
+      <div class="metrics"></div>
+    </div>
+    <div class="task" data-start="2024-06-02T10:00" data-end="2024-06-02T12:30">
+      <strong>Criar interface</strong>
+      <div class="metrics"></div>
+    </div>
+  </div>
+  <div class="column">
+    <h2>Fazendo</h2>
+    <div class="task" data-start="2024-06-03T14:00" data-end="2024-06-03T17:30">
+      <strong>Implementar arrastar e soltar</strong>
+      <div class="metrics"></div>
+    </div>
+  </div>
+  <div class="column">
+    <h2>Concluído</h2>
+    <div class="task" data-start="2024-05-30T08:00" data-end="2024-05-30T10:30">
+      <strong>Estrutura inicial</strong>
+      <div class="metrics"></div>
+    </div>
+  </div>
+</div>
+<script>
+  document.querySelectorAll('.task').forEach(task => {
+    const start = new Date(task.dataset.start);
+    const end = new Date(task.dataset.end);
+    const diffMs = end - start;
+    const hours = Math.floor(diffMs / (1000 * 60 * 60));
+    const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+    task.querySelector('.metrics').textContent = `Duração: ${hours}h ${minutes}min`;
+  });
+</script>
+</body>
+</html>

--- a/board.html
+++ b/board.html
@@ -7,15 +7,24 @@
 <style>
   body {font-family: Arial, sans-serif; margin: 20px; background: #f6f6f6;}
   h1 {text-align: center; color: #6a0dad;}
-  .board {display: flex; justify-content: space-between; gap: 20px;}
+  .board {display: flex; justify-content: space-between; gap: 20px; margin-top:20px;}
   .column {background: #fff; border-radius: 4px; flex: 1; padding: 10px; box-shadow: 0 0 5px rgba(0,0,0,0.1);}
   .column h2 {text-align: center; color: #6a0dad;}
-  .task {border: 1px solid #ddd; border-radius: 4px; padding: 8px; margin-bottom: 10px; background: #fafafa;}
+  .task {border: 1px solid #ddd; border-radius: 4px; padding: 8px; margin-bottom: 10px; background: #fafafa; cursor: grab;}
   .metrics {font-size: 0.85em; color: #555; margin-top: 4px;}
+  .add-task {display:flex; gap:10px; margin-top:20px;}
+  .add-task input{padding:5px;}
+  .add-task button{padding:5px 10px; background:#6a0dad; color:#fff; border:none; border-radius:4px; cursor:pointer;}
 </style>
 </head>
 <body>
 <h1>MVP de Gerenciamento de Tarefas</h1>
+<div class="add-task">
+  <input type="text" id="taskTitle" placeholder="Título da tarefa">
+  <input type="datetime-local" id="taskStart">
+  <input type="datetime-local" id="taskEnd">
+  <button id="addTask">Adicionar</button>
+</div>
 <div class="board">
   <div class="column">
     <h2>A Fazer</h2>
@@ -44,13 +53,55 @@
   </div>
 </div>
 <script>
-  document.querySelectorAll('.task').forEach(task => {
+  function computeMetrics(task) {
     const start = new Date(task.dataset.start);
     const end = new Date(task.dataset.end);
     const diffMs = end - start;
     const hours = Math.floor(diffMs / (1000 * 60 * 60));
     const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
     task.querySelector('.metrics').textContent = `Duração: ${hours}h ${minutes}min`;
+  }
+
+  let dragId = 0;
+  document.querySelectorAll('.task').forEach(task => {
+    task.setAttribute('draggable', 'true');
+    task.id = 'task-' + dragId++;
+    computeMetrics(task);
+    task.addEventListener('dragstart', e => {
+      e.dataTransfer.setData('text/plain', e.target.id);
+    });
+  });
+
+  document.querySelectorAll('.column').forEach(col => {
+    col.addEventListener('dragover', e => e.preventDefault());
+    col.addEventListener('drop', e => {
+      e.preventDefault();
+      const id = e.dataTransfer.getData('text/plain');
+      const el = document.getElementById(id);
+      if (el) col.appendChild(el);
+    });
+  });
+
+  document.getElementById('addTask').addEventListener('click', () => {
+    const title = document.getElementById('taskTitle').value.trim();
+    const start = document.getElementById('taskStart').value;
+    const end = document.getElementById('taskEnd').value;
+    if (!title || !start || !end) return;
+    const task = document.createElement('div');
+    task.className = 'task';
+    task.setAttribute('draggable', 'true');
+    task.dataset.start = start;
+    task.dataset.end = end;
+    task.id = 'task-' + dragId++;
+    task.innerHTML = `<strong>${title}</strong><div class="metrics"></div>`;
+    computeMetrics(task);
+    task.addEventListener('dragstart', e => {
+      e.dataTransfer.setData('text/plain', e.target.id);
+    });
+    document.querySelector('.column').appendChild(task);
+    document.getElementById('taskTitle').value = '';
+    document.getElementById('taskStart').value = '';
+    document.getElementById('taskEnd').value = '';
   });
 </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -56,6 +56,9 @@
       <input type="password" placeholder="Senha" required>
       <button type="submit">Entrar</button>
     </form>
+    <p style="text-align:center;margin-top:10px;">
+      <a href="board.html">Ir para o quadro de tarefas</a>
+    </p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a board page showing tasks grouped by status
- compute and display task duration metrics
- link the new board page from the login screen

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688be9cfe0688322976d8313db7a8ce8